### PR TITLE
Fix test suite

### DIFF
--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('basic environment', () => {
+  it('runs vitest successfully', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/test/estimateCost.test.ts
+++ b/test/estimateCost.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { estimateCost } from '../src/utils/llm-providers';
+
+describe('estimateCost', () => {
+  it('calculates cost using model specific rates', () => {
+    const cost = estimateCost('openai', 1000, 500);
+    expect(cost).toBeCloseTo(0.002 + 0.004, 6);
+  });
+
+  it('defaults to openai rates when model is unknown', () => {
+    const cost = estimateCost('unknown', 1000, 1000);
+    expect(cost).toBeCloseTo(0.002 + 0.008, 6);
+  });
+});

--- a/test/validateApiKeys.test.ts
+++ b/test/validateApiKeys.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { validateApiKeys } from '../src/utils/api-keys';
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe('validateApiKeys', () => {
+  it('detects missing API keys', () => {
+    delete process.env.OPENAI_API_KEY;
+    const result = validateApiKeys(['openai']);
+    expect(result.valid).toBe(false);
+    expect(result.missingKeys).toContain('OPENAI_API_KEY');
+  });
+
+  it('detects invalid API key format', () => {
+    process.env.OPENAI_API_KEY = 'invalid';
+    const result = validateApiKeys(['openai']);
+    expect(result.valid).toBe(false);
+    expect(result.invalidKeys).toContain('OPENAI_API_KEY');
+  });
+
+  it('passes when API key is valid', () => {
+    process.env.OPENAI_API_KEY = 'sk-' + 'a'.repeat(40);
+    const result = validateApiKeys(['openai']);
+    expect(result.valid).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a minimal vitest test so `npm test` passes
- add tests for `estimateCost` utility
- add tests for API key validation

## Testing
- `npm test`

## Summary by Sourcery

Add a minimal Vitest setup and expand test coverage with tests for the estimateCost utility and API key validation

Tests:
- Add a basic Vitest test to ensure `npm test` passes
- Add unit tests for the `estimateCost` utility
- Add unit tests for API key validation covering missing, invalid, and valid key cases