### PR TITLE
Fix mismatched typedef

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,13 +1,17 @@
+import type { CliOptions } from './types/report';
+
 export interface TriumvirateReviewOptions {
-    models: string[];
-    exclude: string[];
-    diffOnly: boolean;
+    models?: string[];
+    exclude?: string[];
+    diffOnly?: boolean;
     outputPath?: string;
-    failOnError: boolean;
-    summaryOnly: boolean;
+    failOnError?: boolean;
+    summaryOnly?: boolean;
     tokenLimit?: number;
     reviewType?: string;
-    repomixOptions?: RepomixPassthroughOptions;
+    repomixOptions?: RepomixPassthroughOptions | Record<string, unknown>;
+    enhancedReport?: boolean;
+    options?: CliOptions;
 }
 
 export interface RepomixPassthroughOptions {


### PR DESCRIPTION
## Summary
- update `src/index.d.ts` so the public types match current `runTriumvirateReview` options

## Testing
- `npm test` *(fails: vitest not found)*

## Summary by Sourcery

Align the public TypeScript definitions for TriumvirateReviewOptions with the actual runtime options by making fields optional, extending types, and adding missing properties

Enhancements:
- Make all previously required TriumvirateReviewOptions fields optional
- Add enhancedReport and options properties (the latter using imported CliOptions)
- Extend repomixOptions to accept a generic Record<string, unknown> alongside RepomixPassthroughOptions
- Import CliOptions from report types for the new options property