### PR TITLE
Fix lint failures and type errors

### DIFF
--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 describe('basic environment', () => {
-  it('runs vitest successfully', () => {
-    expect(true).toBe(true);
-  });
+    it('runs vitest successfully', () => {
+        expect(true).toBe(true);
+    });
 });

--- a/test/estimateCost.test.ts
+++ b/test/estimateCost.test.ts
@@ -1,14 +1,15 @@
 import { describe, it, expect } from 'vitest';
+
 import { estimateCost } from '../src/utils/llm-providers';
 
 describe('estimateCost', () => {
-  it('calculates cost using model specific rates', () => {
-    const cost = estimateCost('openai', 1000, 500);
-    expect(cost).toBeCloseTo(0.002 + 0.004, 6);
-  });
+    it('calculates cost using model specific rates', () => {
+        const cost = estimateCost('openai', 1000, 500);
+        expect(cost).toBeCloseTo(0.002 + 0.004, 6);
+    });
 
-  it('defaults to openai rates when model is unknown', () => {
-    const cost = estimateCost('unknown', 1000, 1000);
-    expect(cost).toBeCloseTo(0.002 + 0.008, 6);
-  });
+    it('defaults to openai rates when model is unknown', () => {
+        const cost = estimateCost('unknown', 1000, 1000);
+        expect(cost).toBeCloseTo(0.002 + 0.008, 6);
+    });
 });

--- a/test/validateApiKeys.test.ts
+++ b/test/validateApiKeys.test.ts
@@ -1,34 +1,35 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
 import { validateApiKeys } from '../src/utils/api-keys';
 
 const originalEnv = { ...process.env };
 
 beforeEach(() => {
-  process.env = { ...originalEnv };
+    process.env = { ...originalEnv };
 });
 
 afterEach(() => {
-  process.env = { ...originalEnv };
+    process.env = { ...originalEnv };
 });
 
 describe('validateApiKeys', () => {
-  it('detects missing API keys', () => {
-    delete process.env.OPENAI_API_KEY;
-    const result = validateApiKeys(['openai']);
-    expect(result.valid).toBe(false);
-    expect(result.missingKeys).toContain('OPENAI_API_KEY');
-  });
+    it('detects missing API keys', () => {
+        delete process.env.OPENAI_API_KEY;
+        const result = validateApiKeys(['openai']);
+        expect(result.valid).toBe(false);
+        expect(result.missingKeys).toContain('OPENAI_API_KEY');
+    });
 
-  it('detects invalid API key format', () => {
-    process.env.OPENAI_API_KEY = 'invalid';
-    const result = validateApiKeys(['openai']);
-    expect(result.valid).toBe(false);
-    expect(result.invalidKeys).toContain('OPENAI_API_KEY');
-  });
+    it('detects invalid API key format', () => {
+        process.env.OPENAI_API_KEY = 'invalid';
+        const result = validateApiKeys(['openai']);
+        expect(result.valid).toBe(false);
+        expect(result.invalidKeys).toContain('OPENAI_API_KEY');
+    });
 
-  it('passes when API key is valid', () => {
-    process.env.OPENAI_API_KEY = 'sk-' + 'a'.repeat(40);
-    const result = validateApiKeys(['openai']);
-    expect(result.valid).toBe(true);
-  });
+    it('passes when API key is valid', () => {
+        process.env.OPENAI_API_KEY = 'sk-' + 'a'.repeat(40);
+        const result = validateApiKeys(['openai']);
+        expect(result.valid).toBe(true);
+    });
 });


### PR DESCRIPTION
## Summary
- adjust import groups in tests
- avoid type errors in Gemini provider implementation
- ensure lint/format passes

## Testing
- `npm run verify`
- `npm test`
- `npm run build`

## Summary by Sourcery

Fix lint and type errors across the codebase by adjusting test file formatting and enhancing type safety in the GeminiProvider implementation.

Bug Fixes:
- Resolve type errors in GeminiProvider by adding explicit type guards, casts, and proper handling of functionCalls

Enhancements:
- Consolidate usage.total_tokens assignment logic
- Refactor import syntax and inline disable specific TypeScript lint rules for compliance

Tests:
- Adjust import grouping and indentation in test files to satisfy lint rules