### PR TITLE
Add GitHub Action runner

### DIFF
--- a/.github/actions/triumvirate-review/action.yml
+++ b/.github/actions/triumvirate-review/action.yml
@@ -1,0 +1,10 @@
+name: 'Triumvirate Review'
+description: 'Run Triumvirate code review'
+inputs:
+  mode:
+    description: 'Execution mode: normal or strict'
+    required: false
+    default: 'normal'
+runs:
+  using: 'node20'
+  main: '../../scripts/github-action.js'

--- a/.github/workflows/tri-review.yml
+++ b/.github/workflows/tri-review.yml
@@ -13,11 +13,9 @@ jobs:
         with:
           node-version: '20'
       - run: npm install
-      - run: |
-          export OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
-          export ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-          export GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}
-          npx triumvirate --models openai,claude,gemini --diff --output triumvirate.json --fail-on-error
+      - uses: ./.github/actions/triumvirate-review
+        with:
+          mode: strict
       - name: Upload Review Output
         uses: actions/upload-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -206,11 +206,9 @@ jobs:
         with:
           node-version: '20'
       - run: npm install
-      - run: |
-          export OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
-          export ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-          export GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}
-          npx triumvirate --models openai,claude,gemini --diff --output triumvirate.json --fail-on-error
+      - uses: ./.github/actions/triumvirate-review
+        with:
+          mode: strict # or 'normal'
       - name: Upload Review Output
         uses: actions/upload-artifact@v3
         with:

--- a/scripts/github-action.js
+++ b/scripts/github-action.js
@@ -1,0 +1,12 @@
+import { execSync } from 'child_process';
+
+export function runAction(mode = 'normal', execFn = execSync) {
+    const failFlag = mode === 'strict' ? '--fail-on-error' : '';
+    const command = `npx triumvirate --models openai,claude,gemini --diff --output triumvirate.json ${failFlag}`.trim();
+    execFn(command, { stdio: 'inherit' });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+    const mode = process.env.INPUT_MODE || 'normal';
+    runAction(mode);
+}

--- a/test/github-action.test.ts
+++ b/test/github-action.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runAction } from '../scripts/github-action.js';
+
+describe('github action runner', () => {
+    it('adds fail-on-error flag in strict mode', () => {
+        const exec = vi.fn();
+        runAction('strict', exec);
+        expect(exec).toHaveBeenCalled();
+        expect(exec.mock.calls[0][0]).toContain('--fail-on-error');
+    });
+
+    it('runs without fail-on-error in normal mode', () => {
+        const exec = vi.fn();
+        runAction('normal', exec);
+        expect(exec).toHaveBeenCalled();
+        expect(exec.mock.calls[0][0]).not.toContain('--fail-on-error');
+    });
+});


### PR DESCRIPTION
## Summary
- create reusable Triumvirate GitHub action
- update workflow to use the new action
- provide README example for using action
- support action runner with tests

## Testing
- `npm test`

## Summary by Sourcery

Provide a reusable GitHub Action for Triumvirate code reviews, update workflows to leverage it with configurable modes, and add corresponding tests and documentation

New Features:
- Add a reusable 'Triumvirate Review' GitHub Action backed by a Node.js runner script
- Introduce configurable execution modes (strict or normal) via action inputs

Enhancements:
- Refactor CI workflows and README to use the new Triumvirate Review action instead of inline commands

Documentation:
- Include example usage of the Triumvirate Review action in the README

Tests:
- Add unit tests for the GitHub Action runner