### PR TITLE
Schedule LLM cost updates on Friday nights

### DIFF
--- a/.github/workflows/update-llm-costs.yml
+++ b/.github/workflows/update-llm-costs.yml
@@ -2,8 +2,8 @@ name: Update LLM Costs
 
 on:
   schedule:
-    # Runs at 2:00 AM UTC every Sunday
-    - cron: '0 2 * * 0'
+    # Runs at 11:00 PM UTC every Friday
+    - cron: '0 23 * * 5'
   workflow_dispatch:
 
 jobs:
@@ -37,9 +37,14 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Commit and push if llm_costs.json changed
+      - name: Commit llm_costs.json if changed
         if: steps.git-diff.outputs.changed == 'true'
         run: |
           git add llm_costs.json
           git commit -m "chore: update llm_costs.json [automated]"
-          git push origin main
+
+      - name: Bump version and push release
+        if: steps.git-diff.outputs.changed == 'true'
+        run: |
+          npm version patch -m "chore: release v%s [automated]"
+          git push origin main --follow-tags


### PR DESCRIPTION
## Summary
- run update_costs workflow every Friday night at 11pm
- bump package version and push release when llm_costs.json changes

## Testing
- `npm test`
- `npm run build`
- `npm run verify`

## Summary by Sourcery

Schedule the Update LLM Costs workflow to run every Friday night at 23:00 UTC and automate version bumping and release publishing when llm_costs.json changes

CI:
- Reschedule the update-llm-costs GitHub Actions workflow to run at 11:00 PM UTC every Friday instead of Sunday at 2:00 AM
- Add a step to bump the npm package version and push release tags when llm_costs.json is updated