### PR TITLE
Add provider/model specification for models

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -33,7 +33,7 @@ tri --help
 tri review
 
 # Run a code review with specific models
-tri review --models openai,claude
+tri review --models openai/gpt-4.1,anthropic/claude-3-7-sonnet-20250219
 
 # Run a security-focused review
 tri review --review-type security
@@ -66,7 +66,7 @@ tri uninstall
 
 #### Model Options
 
-- `-m, --models <models>`: Comma-separated list of models (default: openai,claude,gemini)
+- `-m, --models <models>`: Comma-separated list of models (default: openai/gpt-4.1,anthropic/claude-3-7-sonnet-20250219,google/gemini-2.5-pro-exp-03-25)
 
 ### Output Options
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ GOOGLE_API_KEY=your-google-key
 tri review
 
 # Run a review with specific models
-tri review --models openai,claude
+tri review --models openai/gpt-4.1,anthropic/claude-3-7-sonnet-20250219
 
 # Run a security-focused review
 tri review --review-type security
@@ -91,7 +91,7 @@ tri review [options]
 
 #### Model Options
 
-- `-m, --models <models>` - Comma-separated list of models (default: openai,claude,gemini)
+- `-m, --models <models>` - Comma-separated list of models (default: openai/gpt-4.1,anthropic/claude-3-7-sonnet-20250219,google/gemini-2.5-pro-exp-03-25)
 - `--review-type <type>` - Type of review: general, security, performance, architecture, docs
 - `--fail-on-error` - Exit with non-zero code if any model fails
 - `--skip-api-key-validation` - Skip API key validation check
@@ -163,7 +163,7 @@ tri review --review-type security --output security-review.json
 ### Only Review Changed Files
 
 ```bash
-tri review --diff --models openai
+tri review --diff --models openai/gpt-4.1
 ```
 
 ### Focus on Specific Files with Compression
@@ -210,7 +210,7 @@ jobs:
           export OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
           export ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
           export GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}
-          npx triumvirate --models openai,claude,gemini --diff --output triumvirate.json --fail-on-error
+          npx triumvirate --models openai/gpt-4.1,anthropic/claude-3-7-sonnet-20250219,google/gemini-2.5-pro-exp-03-25 --diff --output triumvirate.json --fail-on-error
       - name: Upload Review Output
         uses: actions/upload-artifact@v3
         with:

--- a/src/cli/actions/runAction.ts
+++ b/src/cli/actions/runAction.ts
@@ -32,7 +32,7 @@ export const runCliAction = async (directories: string[], options: CliOptions) =
 
     // Process the CLI options
     const {
-        models = 'openai,claude,gemini',
+        models = 'openai/gpt-4.1,anthropic/claude-3-7-sonnet-20250219,google/gemini-2.5-pro-exp-03-25',
         ignore = '',
         diff = false,
         output,

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -51,7 +51,7 @@ export const run = async () => {
             // Triumvirate-specific options
             .option(
                 '-m, --models <models>',
-                'comma-separated list of models (default: openai,claude,gemini)'
+                'comma-separated list of models (default: openai/gpt-4.1,anthropic/claude-3-7-sonnet-20250219,google/gemini-2.5-pro-exp-03-25)'
             )
             .option(
                 '--review-type <type>',

--- a/src/utils/api-keys.ts
+++ b/src/utils/api-keys.ts
@@ -18,7 +18,7 @@ export const MODEL_API_KEYS: ApiKeyRequirements[] = [
         minLength: 39,
     },
     {
-        model: 'claude',
+        model: 'anthropic',
         envVar: 'ANTHROPIC_API_KEY',
         format: /^sk-ant-[A-Za-z0-9_-]{32,}$/,
         minLength: 39,
@@ -65,7 +65,8 @@ export function validateApiKeys(requestedModels: string[]): ApiKeyValidationResu
 
         // Check each requested model
         for (const modelName of requestedModels) {
-            const requirement = MODEL_API_KEYS.find(req => req.model === modelName);
+            const provider = modelName.split('/')[0];
+            const requirement = MODEL_API_KEYS.find(req => req.model === provider);
 
             if (!requirement) {
                 console.warn(`Unknown model: ${modelName}, skipping API key validation`);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,11 +14,11 @@ export const COST_RATES = {
         input: 0.000002,
         output: 0.000008,
     },
-    claude: {
+    anthropic: {
         input: 0.000003, // $3 per 1M tokens (text / image / video)
         output: 0.000015, // $15 per 1M tokens (text / image / video)
     },
-    gemini: {
+    google: {
         // Currently free, but we're assuming a price of https://ai.google.dev/gemini-api/docs/pricing
         input: 0.0, // $0.10 per 1M tokens (text / image / video)
         output: 0.0, // $0.40 per 1M tokens (text / image / video)
@@ -44,7 +44,11 @@ export enum ReviewType {
 
 // Default values for triumvirate review options
 export const DEFAULT_REVIEW_OPTIONS = {
-    MODELS: ['openai', 'claude', 'gemini'],
+    MODELS: [
+        'openai/gpt-4.1',
+        'anthropic/claude-3-7-sonnet-20250219',
+        'google/gemini-2.5-pro-exp-03-25',
+    ],
     EXCLUDE: [],
     DIFF_ONLY: false,
     OUTPUT_PATH: '.',

--- a/src/utils/llm-providers.ts
+++ b/src/utils/llm-providers.ts
@@ -12,6 +12,7 @@ import { COST_RATES } from './constants';
 import { enhancedLogger } from './enhanced-logger.js';
 import { withErrorHandlingAndRetry } from './error-handling';
 import { createModelError, handleModelError, ErrorCategory } from './model-utils';
+import llmCosts from '../../llm_costs.json' assert { type: 'json' };
 import type { OpenAIUsage } from '../types/usage';
 
 // Constants
@@ -49,27 +50,35 @@ export interface LLMProvider {
  * Estimate the cost of a model run based on input and output tokens
  */
 export function estimateCost(model: string, inputTokens: number, outputTokens: number): number {
-    // Use the provided output tokens directly
+    // Try to look up exact model in the costs file
+    const costs = llmCosts as Record<
+        string,
+        { input_cost_per_token?: number; output_cost_per_token?: number }
+    >;
 
-    // Set rates based on model
-    let inputRate = 0.0;
-    let outputRate = 0.0;
-
-    // Use rates from constants
-    if (model in COST_RATES) {
-        inputRate = COST_RATES[model as keyof typeof COST_RATES].input;
-        outputRate = COST_RATES[model as keyof typeof COST_RATES].output;
-    } else {
-        // Default to OpenAI rates if model not found
-        inputRate = COST_RATES.openai.input;
-        outputRate = COST_RATES.openai.output;
+    let info = costs[model];
+    if (!info) {
+        const parts = model.split('/');
+        if (parts.length > 1) {
+            info = costs[parts.slice(1).join('/')];
+        }
     }
 
-    // Calculate cost
-    const inputCost = inputTokens * inputRate;
-    const outputCost = outputTokens * outputRate;
+    if (info && info.input_cost_per_token && info.output_cost_per_token) {
+        return inputTokens * info.input_cost_per_token + outputTokens * info.output_cost_per_token;
+    }
 
-    return inputCost + outputCost;
+    // Fallback to provider level rates
+    const provider = model.split('/')[0] ?? '';
+    if (provider in COST_RATES) {
+        return (
+            inputTokens * COST_RATES[provider as keyof typeof COST_RATES].input +
+            outputTokens * COST_RATES[provider as keyof typeof COST_RATES].output
+        );
+    }
+
+    // Default to OpenAI rates if everything else fails
+    return inputTokens * COST_RATES.openai.input + outputTokens * COST_RATES.openai.output;
 }
 
 /**
@@ -77,7 +86,11 @@ export function estimateCost(model: string, inputTokens: number, outputTokens: n
  */
 export class ClaudeProvider implements LLMProvider {
     name = 'Claude';
-    model = 'claude-3-7-sonnet-20250219';
+    model: string;
+
+    constructor(model = 'claude-3-7-sonnet-20250219') {
+        this.model = model;
+    }
 
     isAvailable(): boolean {
         return !!process.env['ANTHROPIC_API_KEY'];
@@ -293,7 +306,11 @@ export class ClaudeProvider implements LLMProvider {
  */
 export class OpenAIProvider implements LLMProvider {
     name = 'OpenAI';
-    model = 'gpt-4.1';
+    model: string;
+
+    constructor(model = 'gpt-4.1') {
+        this.model = model;
+    }
 
     isAvailable(): boolean {
         return !!process.env['OPENAI_API_KEY'];
@@ -508,7 +525,11 @@ export class OpenAIProvider implements LLMProvider {
  */
 export class GeminiProvider implements LLMProvider {
     name = 'Gemini';
-    model = 'gemini-2.5-pro-exp-03-25';
+    model: string;
+
+    constructor(model = 'gemini-2.5-pro-exp-03-25') {
+        this.model = model;
+    }
 
     isAvailable(): boolean {
         return !!process.env['GOOGLE_API_KEY'];

--- a/test/estimateCost.test.ts
+++ b/test/estimateCost.test.ts
@@ -4,12 +4,12 @@ import { estimateCost } from '../src/utils/llm-providers';
 
 describe('estimateCost', () => {
     it('calculates cost using model specific rates', () => {
-        const cost = estimateCost('openai', 1000, 500);
+        const cost = estimateCost('openai/gpt-4.1', 1000, 500);
         expect(cost).toBeCloseTo(0.002 + 0.004, 6);
     });
 
     it('defaults to openai rates when model is unknown', () => {
-        const cost = estimateCost('unknown', 1000, 1000);
+        const cost = estimateCost('unknown/provider', 1000, 1000);
         expect(cost).toBeCloseTo(0.002 + 0.008, 6);
     });
 });

--- a/test/validateApiKeys.test.ts
+++ b/test/validateApiKeys.test.ts
@@ -15,21 +15,21 @@ afterEach(() => {
 describe('validateApiKeys', () => {
     it('detects missing API keys', () => {
         delete process.env.OPENAI_API_KEY;
-        const result = validateApiKeys(['openai']);
+        const result = validateApiKeys(['openai/gpt-4.1']);
         expect(result.valid).toBe(false);
         expect(result.missingKeys).toContain('OPENAI_API_KEY');
     });
 
     it('detects invalid API key format', () => {
         process.env.OPENAI_API_KEY = 'invalid';
-        const result = validateApiKeys(['openai']);
+        const result = validateApiKeys(['openai/gpt-4.1']);
         expect(result.valid).toBe(false);
         expect(result.invalidKeys).toContain('OPENAI_API_KEY');
     });
 
     it('passes when API key is valid', () => {
         process.env.OPENAI_API_KEY = 'sk-' + 'a'.repeat(40);
-        const result = validateApiKeys(['openai']);
+        const result = validateApiKeys(['openai/gpt-4.1']);
         expect(result.valid).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
- allow specifying provider and model using `provider/model` syntax
- load pricing info from `llm_costs.json` in `estimateCost`
- update default models, API key handling and CLI help
- adjust docs for new syntax
- update tests for provider/model format

## Testing
- `npm test`
- `npm run verify`

## Summary by Sourcery

Introduce provider/model syntax for specifying LLMs, centralize cost rate loading from llm_costs.json with fallback logic, update default models and API key handling, and align documentation and tests with the new format

New Features:
- Support "provider/model" notation across CLI, configuration, and API to specify LLMs
- Load token pricing data from llm_costs.json in estimateCost, with exact model and provider fallback

Enhancements:
- Refactor estimateCost to try exact model lookup in llm_costs and fallback to provider rates or OpenAI defaults
- Allow provider classes (OpenAI, Claude, Gemini) to accept model overrides via constructor parameters
- Update default models list in constants and CLI to use fully qualified provider/model strings
- Modify API key validation to derive provider prefix from model spec

Documentation:
- Update README and CLI documentation to reflect provider/model syntax and updated default models

Tests:
- Adjust estimateCost and API key validation tests to use provider/model format