### PR TITLE
Make token limit dynamic

### DIFF
--- a/src/cli/actions/runAction.ts
+++ b/src/cli/actions/runAction.ts
@@ -38,7 +38,7 @@ export const runCliAction = async (directories: string[], options: CliOptions) =
         output,
         failOnError = false,
         summaryOnly = false,
-        tokenLimit = 100000,
+        tokenLimit,
         reviewType = 'general',
         skipApiKeyValidation = false,
         enhancedReport = true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { runModelReview } from './models';
 import { runRepomix } from './repomix';
 import type { CliOptions, CodeReviewReport, ModelReviewResult } from './types/report';
 import { normalizeUsage } from './types/usage';
-import { DEFAULT_REVIEW_OPTIONS } from './utils/constants';
+import { DEFAULT_REVIEW_OPTIONS, getDynamicTokenLimit } from './utils/constants';
 import { estimateCost } from './utils/llm-providers';
 import { generateCodeReviewReport, formatReportAsMarkdown } from './utils/report-utils';
 
@@ -39,7 +39,7 @@ export async function runTriumvirateReview({
     outputPath = DEFAULT_REVIEW_OPTIONS.OUTPUT_PATH,
     failOnError = DEFAULT_REVIEW_OPTIONS.FAIL_ON_ERROR,
     summaryOnly = DEFAULT_REVIEW_OPTIONS.SUMMARY_ONLY, // eslint-disable-line @typescript-eslint/no-unused-vars
-    tokenLimit = DEFAULT_REVIEW_OPTIONS.TOKEN_LIMIT,
+    tokenLimit,
     reviewType = DEFAULT_REVIEW_OPTIONS.REVIEW_TYPE,
     repomixOptions = {},
     enhancedReport = true, // Enable enhanced reporting by default
@@ -47,7 +47,11 @@ export async function runTriumvirateReview({
 }: TriumvirateReviewOptions = {}) {
     // Initialize results array
     const results = [];
-    //  throw Error("as")
+    // Determine the effective token limit based on selected models if not provided
+    const effectiveTokenLimit =
+        typeof tokenLimit === 'number' && !Number.isNaN(tokenLimit)
+            ? tokenLimit
+            : getDynamicTokenLimit(models);
 
     console.log('Packaging codebase with repomix...');
 
@@ -55,7 +59,7 @@ export async function runTriumvirateReview({
     const mergedRepomixOptions = {
         exclude,
         diffOnly,
-        tokenLimit,
+        tokenLimit: effectiveTokenLimit,
         ...repomixOptions,
     };
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -25,6 +25,25 @@ export const COST_RATES = {
     },
 };
 
+/**
+ * Maximum context window sizes for supported models
+ */
+export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+    openai: 128000,
+    claude: 200000,
+    gemini: 2000000,
+};
+
+/**
+ * Determine the smallest context window for the given models
+ */
+export function getDynamicTokenLimit(models: string[]): number {
+    const limits = models.map(
+        model => MODEL_CONTEXT_WINDOWS[model.toLowerCase()] ?? DEFAULT_REVIEW_OPTIONS.TOKEN_LIMIT
+    );
+    return Math.min(...limits);
+}
+
 // Maximum number of retries for API calls
 export const MAX_API_RETRIES = 3;
 


### PR DESCRIPTION
## Summary
- adjust CLI to accept optional `tokenLimit`
- compute token limit dynamically based on selected models
- add context window map and helper

## Testing
- `npm test`
- `npm run build`
- `npm run verify`

## Summary by Sourcery

Make token limit dynamic by deriving it from model context windows and allowing optional overrides via the CLI

Enhancements:
- Introduce MODEL_CONTEXT_WINDOWS and getDynamicTokenLimit helper to determine context window sizes per model
- Allow tokenLimit option to be omitted in CLI and runTriumvirateReview and compute an effective limit dynamically
- Use dynamic token limit when packaging repomix options to enforce model-specific context windows