### PR TITLE
Add task and doc flags to review

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -36,7 +36,7 @@ tri review
 tri review --models openai,claude
 
 # Run a security-focused review
-tri review --review-type security
+tri review --task security
 
 # Just run the summary from an existing set of raw reports
 tri summarize --input raw-reports.json --output summary.md
@@ -89,7 +89,9 @@ tri uninstall
 
 ### Review Options
 
-- `--review-type <type>`: Type of review: general, security, performance, architecture, docs
+- `--review-type <type>`: **Deprecated**. Use `--task` instead. Suggested types: general, security, performance, architecture, docs
+- `--task <task>`: Task description to customize the system prompt (e.g. security, performance, architecture, docs)
+- `--doc <path>`: Documentation file or URL (can be repeated)
 - `--token-limit <number>`: Maximum tokens to send to the model
 - `--fail-on-error`: Exit with non-zero code if any model fails
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ tri review
 tri review --models openai,claude
 
 # Run a security-focused review
-tri review --review-type security
+tri review --task security
 ```
 
 <!-- PLACEHOLDER: Add screenshot of review output -->
@@ -92,7 +92,9 @@ tri review [options]
 #### Model Options
 
 - `-m, --models <models>` - Comma-separated list of models (default: openai,claude,gemini)
-- `--review-type <type>` - Type of review: general, security, performance, architecture, docs
+- `--review-type <type>` - **Deprecated**. Use `--task` instead. Suggested types: general, security, performance, architecture, docs
+- `--task <task>` - Task description to customize the system prompt (e.g. security, performance, architecture, docs)
+- `--doc <path>` - Documentation file or URL (repeatable)
 - `--fail-on-error` - Exit with non-zero code if any model fails
 - `--skip-api-key-validation` - Skip API key validation check
 - `--enhanced-report` - Generate enhanced report with model agreement analysis (default: true)
@@ -157,7 +159,14 @@ tri next [options]
 ### Focused Security Review
 
 ```bash
-tri review --review-type security --output security-review.json
+tri review --task security --output security-review.json
+```
+
+### Custom Task with Documentation
+
+```bash
+tri review --task "focus on security, sql injections" \
+  --doc ./SECURITY.md --doc https://example.com/guide
 ```
 
 ### Only Review Changed Files

--- a/scripts/github-action.js
+++ b/scripts/github-action.js
@@ -2,7 +2,8 @@ import { execSync } from 'child_process';
 
 export function runAction(mode = 'normal', execFn = execSync) {
     const failFlag = mode === 'strict' ? '--fail-on-error' : '';
-    const command = `npx triumvirate --models openai,claude,gemini --diff --output triumvirate.json ${failFlag}`.trim();
+    const command =
+        `npx triumvirate --models openai,claude,gemini --diff --output triumvirate.json ${failFlag}`.trim();
     execFn(command, { stdio: 'inherit' });
 }
 

--- a/src/cli/actions/runAction.ts
+++ b/src/cli/actions/runAction.ts
@@ -3,6 +3,7 @@ import type { TriumvirateReviewOptions } from '../../index.js';
 import type { CliOptions } from '../../types/report.js';
 import { processApiKeyValidation } from '../../utils/api-keys.js';
 import { enhancedLogger } from '../../utils/enhanced-logger.js';
+import { resolveDocs, createSystemPrompt } from '../../utils/system-prompt.js';
 
 export const runCliAction = async (directories: string[], options: CliOptions) => {
     // Set log level based on verbose and quiet flags
@@ -40,6 +41,8 @@ export const runCliAction = async (directories: string[], options: CliOptions) =
         summaryOnly = false,
         tokenLimit = 100000,
         reviewType = 'general',
+        task,
+        doc = [],
         skipApiKeyValidation = false,
         enhancedReport = true,
 
@@ -95,6 +98,11 @@ export const runCliAction = async (directories: string[], options: CliOptions) =
             tokenCountEncoding,
         };
 
+        // Resolve documentation and build system prompt
+        const docs = Array.isArray(doc) ? doc : [doc].filter(Boolean);
+        const resolvedDocs = await resolveDocs(docs as string[]);
+        const systemPrompt = await createSystemPrompt(task, resolvedDocs);
+
         // Run the review with our configured options
         const reviewOptions: TriumvirateReviewOptions = {
             models: modelList,
@@ -107,6 +115,7 @@ export const runCliAction = async (directories: string[], options: CliOptions) =
             reviewType,
             repomixOptions,
             enhancedReport,
+            systemPrompt,
         };
 
         const results = await runTriumvirateReview(reviewOptions);

--- a/src/cli/cliRun.ts
+++ b/src/cli/cliRun.ts
@@ -55,7 +55,17 @@ export const run = async () => {
             )
             .option(
                 '--review-type <type>',
-                'type of review: general, security, performance, architecture, docs'
+                'DEPRECATED: use --task instead. Suggested types: general, security, performance, architecture, docs'
+            )
+            .option('--task <task>', 'task description to focus the review')
+            .option(
+                '--doc <path>',
+                'documentation file or URL (can be repeated)',
+                (value, previous: string[] = []) => {
+                    previous.push(value);
+                    return previous;
+                },
+                []
             )
             .option('--fail-on-error', 'exit with non-zero code if any model fails')
             .option('--skip-api-key-validation', 'skip API key validation check')
@@ -97,7 +107,9 @@ Option Groups:
 
   Triumvirate Options:
     -m, --models                    Models to use for code review
-    --review-type                  Type of review to perform
+    --review-type                  DEPRECATED: use --task instead
+    --task                         Task description for the review (e.g. security, performance, architecture, docs)
+    --doc                          Documentation file or URL
     --fail-on-error                Exit with error if any model fails
     --skip-api-key-validation      Skip API key validation
     --enhanced-report              Generate enhanced report with model agreement

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,6 +11,7 @@ export interface TriumvirateReviewOptions {
     reviewType?: string;
     repomixOptions?: RepomixPassthroughOptions | Record<string, unknown>;
     enhancedReport?: boolean;
+    systemPrompt?: string;
     options?: CliOptions;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export interface TriumvirateReviewOptions {
     reviewType?: string;
     repomixOptions?: Record<string, unknown>;
     enhancedReport?: boolean;
+    systemPrompt?: string;
     options?: CliOptions;
 }
 
@@ -43,6 +44,7 @@ export async function runTriumvirateReview({
     reviewType = DEFAULT_REVIEW_OPTIONS.REVIEW_TYPE,
     repomixOptions = {},
     enhancedReport = true, // Enable enhanced reporting by default
+    systemPrompt,
     options = {},
 }: TriumvirateReviewOptions = {}) {
     // Initialize results array
@@ -80,8 +82,10 @@ export async function runTriumvirateReview({
     // Read the packaged codebase
     const codebase = fs.readFileSync(repomixResult.filePath, 'utf8');
 
-    // Step 3: Generate prompt template based on review type
-    const promptTemplate = generatePromptTemplate(reviewType, repomixResult);
+    // Step 3: Generate prompt template based on review type or custom system prompt
+    const promptTemplate = systemPrompt
+        ? `${systemPrompt}\n\n{{CODEBASE}}`
+        : generatePromptTemplate(reviewType, repomixResult);
 
     // Step 4: Generate prompt and send to LLMs
     const prompt = promptTemplate.replace('{{CODEBASE}}', codebase);

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -20,6 +20,8 @@ export interface CliOptions {
     tokenCountEncoding?: string;
     skipApiKeyValidation?: boolean;
     enhancedReport?: boolean;
+    task?: string;
+    doc?: string[];
     verbose?: boolean;
     quiet?: boolean;
     version?: boolean;

--- a/src/utils/system-prompt.ts
+++ b/src/utils/system-prompt.ts
@@ -1,0 +1,64 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * Fetch a URL and save it to a temporary file.
+ * @param url - URL to fetch
+ * @returns Path to the saved file
+ */
+export async function fetchDoc(url: string): Promise<string> {
+    const response = await fetch(url, {
+        headers: { 'User-Agent': 'triumvirate' },
+    });
+    if (!response.ok) {
+        throw new Error(`Failed to fetch ${url}: ${response.status}`);
+    }
+    const text = await response.text();
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tridoc-'));
+    const fileName = path.basename(new URL(url).pathname) || 'doc.txt';
+    const filePath = path.join(tmpDir, fileName);
+    fs.writeFileSync(filePath, text, 'utf8');
+    return filePath;
+}
+
+/**
+ * Resolve a list of docs provided by the user. URLs are fetched and saved
+ * locally, while local paths are validated.
+ * @param docs - Array of file paths or URLs
+ * @returns Array of resolved local file paths
+ */
+export async function resolveDocs(docs: string[]): Promise<string[]> {
+    const resolved: string[] = [];
+    for (const doc of docs) {
+        if (doc.startsWith('http://') || doc.startsWith('https://')) {
+            resolved.push(await fetchDoc(doc));
+        } else {
+            if (!fs.existsSync(doc)) {
+                throw new Error(`Documentation file not found: ${doc}`);
+            }
+            resolved.push(doc);
+        }
+    }
+    return resolved;
+}
+
+/**
+ * Create a system prompt from a task description and documentation files.
+ * @param task - Task description
+ * @param docs - Array of local documentation file paths
+ * @returns Generated system prompt string
+ */
+export async function createSystemPrompt(task?: string, docs: string[] = []): Promise<string> {
+    const parts: string[] = [];
+    if (task) {
+        parts.push(`Task:\n${task}`);
+    }
+    for (const doc of docs) {
+        if (fs.existsSync(doc)) {
+            const content = await fs.promises.readFile(doc, 'utf8');
+            parts.push(`Documentation from ${doc}:\n${content}`);
+        }
+    }
+    return parts.join('\n\n');
+}

--- a/test/github-action.test.ts
+++ b/test/github-action.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+
 import { runAction } from '../scripts/github-action.js';
 
 describe('github action runner', () => {

--- a/test/systemPrompt.test.ts
+++ b/test/systemPrompt.test.ts
@@ -1,0 +1,36 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { resolveDocs, createSystemPrompt } from '../src/utils/system-prompt';
+
+describe('system prompt utilities', () => {
+    it('creates prompt from task and docs', async () => {
+        const tmp = path.join(process.cwd(), 'tmp-doc.txt');
+        fs.writeFileSync(tmp, 'example doc', 'utf8');
+        const prompt = await createSystemPrompt('my task', [tmp]);
+        expect(prompt).toContain('my task');
+        expect(prompt).toContain('example doc');
+        fs.unlinkSync(tmp);
+    });
+
+    it('resolves doc URLs via fetch', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            text: () => Promise.resolve('remote data'),
+        });
+        const originalFetch = global.fetch;
+        // @ts-expect-error override fetch for testing
+        global.fetch = fetchMock;
+
+        const files = await resolveDocs(['https://example.com/doc']);
+        expect(files.length).toBe(1);
+        const content = fs.readFileSync(files[0], 'utf8');
+        expect(content).toBe('remote data');
+
+        fs.unlinkSync(files[0]);
+        // @ts-expect-error restore original fetch
+        global.fetch = originalFetch;
+    });
+});


### PR DESCRIPTION
## Summary
- add `--task` and `--doc` flags to the `review` command
- build custom system prompts from task and docs
- support loading docs from URLs or local files
- document new flags in README and CLI docs
- add tests for system prompt utilities
- deprecate `--review-type` in favor of `--task`

## Testing
- `npm run build`
- `npm test`
- `npm run verify`

## Summary by Sourcery

Enhance the review command by introducing customizable task and documentation inputs, deprecating the legacy review-type option, and integrating a system prompt builder to tailor LLM reviews based on provided tasks and docs.

New Features:
- Add --task flag to focus reviews on a specific task
- Add --doc flag to include multiple documentation files or URLs in the review

Enhancements:
- Deprecate --review-type in favor of the new --task option
- Resolve and load docs from URLs or local files and build a combined system prompt
- Pass the generated system prompt through runTriumvirateReview to customize LLM prompts

Documentation:
- Update README.md and CLI.md to document the new --task and --doc flags and deprecate --review-type

Tests:
- Add unit tests for system-prompt utilities

Chores:
- Extend type definitions to include task, doc, and systemPrompt fields